### PR TITLE
Add BQ11 offer-lifecycle analytics endpoint

### DIFF
--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from app.core.dependencies import get_db
 from app.models.offer import Offer
 from app.models.application import Application
-from app.schemas.analytics import OfferAcceptanceRateOut, OverallInsightsOut, GpaByOfferOut, TopApplicantOut, GpaHighRateOut, ApplicationsPerSemesterOut
+from app.schemas.analytics import OfferAcceptanceRateOut, OverallInsightsOut, GpaByOfferOut, TopApplicantOut, GpaHighRateOut, ApplicationsPerSemesterOut, OfferLifecycleOut
 from app.services.analytics_service import (
     get_acceptance_rate_by_offer,
     get_overall_insights,
@@ -58,6 +58,33 @@ def time_to_first_application(db: Session = Depends(get_db)):
         "offers_with_applications": offers_with_apps,
         "total_offers": len(offers),
     }
+
+
+@router.get("/offer-lifecycle", response_model=OfferLifecycleOut)
+def offer_lifecycle(db: Session = Depends(get_db)):
+    """BQ11 (Santiago Reyes): Offer lifecycle duration statistics.
+
+    Queries closed offers (closed_at IS NOT NULL), computes (closed_at - created_at).days
+    for each, and returns average, min, max days and total count.
+    """
+    offers = db.query(Offer).filter(Offer.closed_at.isnot(None)).all()
+
+    if not offers:
+        return OfferLifecycleOut(average_days=0.0, min_days=0, max_days=0, total_offers=0)
+
+    durations = []
+    for offer in offers:
+        closed = offer.closed_at.replace(tzinfo=None)
+        created = offer.created_at.replace(tzinfo=None)
+        days = abs((closed - created).days)
+        durations.append(days)
+
+    return OfferLifecycleOut(
+        average_days=round(sum(durations) / len(durations), 2),
+        min_days=min(durations),
+        max_days=max(durations),
+        total_offers=len(durations),
+    )
 
 
 @router.get("/acceptance-rate", response_model=list[OfferAcceptanceRateOut])

--- a/app/schemas/analytics.py
+++ b/app/schemas/analytics.py
@@ -85,3 +85,16 @@ class ApplicationsPerSemesterOut(BaseModel):
     total_applications: int
     unique_students: int
     avg_applications_per_student: float
+
+
+class OfferLifecycleOut(BaseModel):
+    """
+    BQ11 (Santiago Reyes): Offer lifecycle duration statistics.
+    Functional scenario: Staff opens analytics -> system queries closed offers,
+    computes (closed_at - created_at).days for each, returns aggregate stats.
+    Quality scenario (Performance): Response time < 2 s for up to 500 offers.
+    """
+    average_days: float
+    min_days: int
+    max_days: int
+    total_offers: int


### PR DESCRIPTION
GET /analytics/offer-lifecycle queries closed offers, computes (closed_at - created_at).days per offer, and returns average, min, max days and total count via OfferLifecycleOut schema.